### PR TITLE
bump electrum_client version in bdk_electrum

### DIFF
--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -13,8 +13,12 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.16.0" }
-electrum-client = { version = "0.20" }
-#rustls = { version = "=0.21.1", optional = true, features = ["dangerous_configuration"] }
+electrum-client = { version = "0.21", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }
+
+[features]
+default = ["use-rustls"]
+use-rustls = ["electrum-client/use-rustls"]
+use-rustls-ring = ["electrum-client/use-rustls-ring"]


### PR DESCRIPTION
This bumps the electrum_client version used by bdk_electrum and adds corresponding features that control the provider used by rustls.

These changes are based on the version of this file in BDK's v1.0.0-beta.2 tag:
https://github.com/bitcoindevkit/bdk/blob/v1.0.0-beta.2/crates/electrum/Cargo.toml

The motivation is to be able to avoid using the default aws-lc-rs provider from rustls when using electrum_client via the bdk_electrum v0.15.x crate.