### PR TITLE
bump electrum-client to 0.23

### DIFF
--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.16.0" }
-electrum-client = { version = "0.21", features = [ "proxy" ], default-features = false }
+electrum-client = { version = "0.23", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }


### PR DESCRIPTION
This bumps the electrum-client crate to 0.23 in the branch currently used by lianad.

The main motivation is to use https://github.com/bitcoindevkit/rust-electrum-client/pull/150 as a prerequisite to fixing https://github.com/wizardsardine/liana/issues/1300. For this, rust-electrum version 0.22 would be sufficient, but bumping to 0.23 includes other important fixes as outlined in https://github.com/bitcoindevkit/rust-electrum-client/blob/master/CHANGELOG.md.